### PR TITLE
test: add GitHub Actions workflow and coverage thresholds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,6 @@ on:
 jobs:
   test-backend:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./backend
 
     steps:
       - name: Checkout code
@@ -32,11 +29,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run tests
-        run: pnpm test:run
+      - name: Run backend tests
+        run: pnpm --filter backend test:run
 
-      - name: Run tests with coverage
-        run: pnpm test:coverage
+      - name: Run backend tests with coverage
+        run: pnpm --filter backend test:coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
@@ -49,9 +46,6 @@ jobs:
 
   test-frontend:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./frontend
 
     steps:
       - name: Checkout code
@@ -72,11 +66,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run tests
-        run: pnpm test:run
+      - name: Run frontend tests
+        run: pnpm --filter frontend test:run
 
-      - name: Run tests with coverage
-        run: pnpm test:coverage
+      - name: Run frontend tests with coverage
+        run: pnpm --filter frontend test:coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,88 @@
+name: Test
+
+on:
+  push:
+    branches: [ dev, main ]
+  pull_request:
+    branches: [ dev, main ]
+
+jobs:
+  test-backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test:run
+
+      - name: Run tests with coverage
+        run: pnpm test:coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./backend/coverage/lcov.info
+          flags: backend
+          name: backend-coverage
+          fail_ci_if_error: false
+
+  test-frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test:run
+
+      - name: Run tests with coverage
+        run: pnpm test:coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./frontend/coverage/lcov.info
+          flags: frontend
+          name: frontend-coverage
+          fail_ci_if_error: false

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -14,6 +14,12 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],
+      thresholds: {
+        lines: 70,
+        functions: 70,
+        branches: 70,
+        statements: 70,
+      },
       exclude: [
         'node_modules/',
         '**/*.d.ts',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest",
+    "test:run": "vitest --run",
     "test:watch": "vitest",
     "test:coverage": "vitest --coverage",
     "test:ui": "vitest --ui"

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -50,6 +50,12 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],
+      thresholds: {
+        lines: 70,
+        functions: 70,
+        branches: 70,
+        statements: 70,
+      },
       exclude: [
         'node_modules/',
         'src/middleware.ts',


### PR DESCRIPTION
## Summary

- ✅ Add `.github/workflows/test.yml` for automated CI/CD testing
- ✅ Add coverage thresholds (70%) to `backend/vitest.config.ts`
- ✅ Add coverage thresholds (70%) to `frontend/vitest.config.ts`

## Changes

### GitHub Actions Workflow
- Trigger: Push and PR to `dev` and `main` branches
- 2 Jobs: `test-backend` and `test-frontend`
- Uses pnpm 9 + Node.js 20 with cache
- Runs tests with coverage
- Uploads to Codecov (optional)

### Coverage Thresholds
- Lines: 70%
- Functions: 70%
- Branches: 70%
- Statements: 70%

## Test plan

- [x] Run tests locally: `pnpm test`
- [x] Run coverage locally: `pnpm test:coverage`
- [x] Verify thresholds work (fails if coverage < 70%)
- [ ] Verify workflow passes on GitHub Actions

## Related

Addresses feedback from May 6th interview:
- "ไม่มี GitHub Actions" → ✅ Created workflow
- "ไม่มี Coverage Threshold" → ✅ Added to config

🤖 Generated with [Claude Code](https://claude.com/claude-code)